### PR TITLE
Suman | BAH-558 | Change descriptions for url pattern key

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -355,7 +355,7 @@
             <column name="property" value="atomfeed.event.urlPatternForSurgicalBlock"/>
             <column name="property_value" value="/openmrs/ws/rest/v1/surgicalBlock/{uuid}?v=full"/>
             <column name="uuid" valueComputed="UUID()"/>
-            <column name="description" value="URL pattern to use for published program events. Default is /openmrs/ws/rest/v1/surgicalBlock/{uuid}?v=full"/>
+            <column name="description" value="URL pattern to use for published surgical block events. Default is /openmrs/ws/rest/v1/surgicalBlock/{uuid}?v=full. If you change default value, please add your custom implementation for the given URL"/>
         </insert>
     </changeSet>
 
@@ -374,7 +374,7 @@
         </insert>
     </changeSet>
 
-    <changeSet id="201806211817" author="Suman">
+    <changeSet id="201807161748" author="Suman">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
                 SELECT COUNT(*) FROM global_property where property = 'atomfeed.event.urlPatternForSurgicalAppointment';
@@ -385,7 +385,7 @@
             <column name="property" value="atomfeed.event.urlPatternForSurgicalAppointment"/>
             <column name="property_value" value="/openmrs/ws/rest/v1/surgicalAppointment/{uuid}?v=full"/>
             <column name="uuid" valueComputed="UUID()"/>
-            <column name="description" value="URL pattern to use for published surgical appointment events. Default is /openmrs/ws/rest/v1/surgicalAppointment/{uuid}?v=full"/>
+            <column name="description" value="URL pattern to use for published surgical appointment events. Default is /openmrs/ws/rest/v1/surgicalAppointment/{uuid}?v=full. If you change default value, please add your custom implementation for the given URL"/>
         </insert>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Updated the description for `atomfeed.event.urlPatternForSurgicalBlock` and `atomfeed.event.urlPatternForSurgicalAppointment` as per discussion with @angshu and @binduak.

Before merging it, please delete the following changeset from `liquibasechangelog` table of openmrs database

- 201806211817
