### PR TITLE
OTM-3 | Fix. Remove schemaName from liquibase changesets

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -277,7 +277,7 @@
     </changeSet>
     <changeSet id="Amman-201707121103" author="Shireesha, Maharjun">
         <preConditions onFail="CONTINUE">
-            <tableExists tableName="surgical_appointment_attribute" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute"/>
         </preConditions>
         <comment>Increase the column size</comment>
         <sql>
@@ -304,12 +304,11 @@
     </changeSet>
     <changeSet id="201807031533" author="Siva, Saikumar" context="rel3.1">
         <preConditions onFail="CONTINUE">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
         </preConditions>
         <comment>Adding unique constraint for name column</comment>
         <addUniqueConstraint columnNames="name"
                              constraintName="unique_attributes"
-                             schemaName="openmrs"
                              tableName="surgical_appointment_attribute_type"/>
     </changeSet>
     <include file="migrations/surgicalAppointmentAttributeTypes.xml" />

--- a/api/src/main/resources/migrations/surgicalAppointmentAttributeTypes.xml
+++ b/api/src/main/resources/migrations/surgicalAppointmentAttributeTypes.xml
@@ -6,7 +6,7 @@
 
     <changeSet id="201807031546-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'procedure'
             </sqlCheck>
@@ -20,7 +20,7 @@
     </changeSet>
     <changeSet id="201807031554-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'estTimeHours'
             </sqlCheck>
@@ -34,7 +34,7 @@
     </changeSet>
     <changeSet id="201807031555-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'estTimeMinutes'
             </sqlCheck>
@@ -48,7 +48,7 @@
     </changeSet>
     <changeSet id="201807031556-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'cleaningTime'
             </sqlCheck>
@@ -62,7 +62,7 @@
     </changeSet>
     <changeSet id="201807031610-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'otherSurgeon'
             </sqlCheck>
@@ -76,7 +76,7 @@
     </changeSet>
     <changeSet id="201807031611-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'surgicalAssistant'
             </sqlCheck>
@@ -90,7 +90,7 @@
     </changeSet>
     <changeSet id="201807031612-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'anaesthetist'
             </sqlCheck>
@@ -104,7 +104,7 @@
     </changeSet>
     <changeSet id="201807031613-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'scrubNurse'
             </sqlCheck>
@@ -118,7 +118,7 @@
     </changeSet>
     <changeSet id="201807031614-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name =
                 'circulatingNurse'
             </sqlCheck>
@@ -132,7 +132,7 @@
     </changeSet>
     <changeSet id="201807031615-1" author="Siva, Saikumar">
         <preConditions onFail="MARK_RAN">
-            <tableExists tableName="surgical_appointment_attribute_type" schemaName="openmrs"/>
+            <tableExists tableName="surgical_appointment_attribute_type"/>
             <sqlCheck expectedResult="0">select count(1) from surgical_appointment_attribute_type where name = 'notes'
             </sqlCheck>
         </preConditions>


### PR DESCRIPTION
This PR removes the hardcoding of schemaName as openmrs in some of the liquibase change-sets. This allows the module to be used with openmrs configured with a database named other than `openmrs`. 

Ref: [JIRA Issue.](https://issues.openmrs.org/browse/OTM-3)