### PR TITLE
OTM-6 | Support concept name lookup for unmapped concepts in OT Patient Observations

### DIFF
--- a/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
+++ b/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
@@ -1,11 +1,10 @@
 package org.openmrs.module.operationtheater.web.resource;
 
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.DateProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.UUIDProperty;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.Obs;
@@ -35,10 +34,13 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.module.webservices.validation.ValidateUtil;
 
 import javax.xml.bind.SchemaOutputResolver;
-import java.util.List;
-import java.util.Set;
-import java.util.ArrayList;
-import java.util.Collections;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.UUIDProperty;
 
 @Resource(name = RestConstants.VERSION_1
         + "/surgicalAppointment", supportedClass = SurgicalAppointment.class, supportedOpenmrsVersions = { "2.0.* - 9.*" })
@@ -119,27 +121,27 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 		}
 		return null;
 	}
-
+	
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
 		if ((rep instanceof DefaultRepresentation) || (rep instanceof RefRepresentation)) {
 			modelImpl.property("id", new IntegerProperty()).property("uuid", new UUIDProperty())
-					.property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
-					.property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
-					.property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
-					.property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
-					.property("surgicalAppointmentAttributes", new StringProperty())
-					.property("patientObservations", new StringProperty());
+			        .property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
+			        .property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
+			        .property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
+			        .property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
+			        .property("surgicalAppointmentAttributes", new StringProperty())
+			        .property("patientObservations", new StringProperty());
 		}
 		if (rep instanceof FullRepresentation) {
 			modelImpl.property("id", new IntegerProperty()).property("uuid", new UUIDProperty())
-					.property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
-					.property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
-					.property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
-					.property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
-					.property("surgicalAppointmentAttributes", new StringProperty())
-					.property("patientObservations", new StringProperty());
+			        .property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
+			        .property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
+			        .property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
+			        .property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
+			        .property("surgicalAppointmentAttributes", new StringProperty())
+			        .property("patientObservations", new StringProperty());
 		}
 		return modelImpl;
 	}
@@ -159,15 +161,15 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 		delegatingResourceDescription.addProperty("surgicalAppointmentAttributes");
 		return delegatingResourceDescription;
 	}
-
+	
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl().property("id", new IntegerProperty()).property("uuid", new UUIDProperty())
-				.property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
-				.property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
-				.property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
-				.property("surgicalBlock", new StringProperty())
-				.property("surgicalAppointmentAttributes", new StringProperty());
+		        .property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
+		        .property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
+		        .property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
+		        .property("surgicalBlock", new StringProperty())
+		        .property("surgicalAppointmentAttributes", new StringProperty());
 	}
 	
 	@PropertyGetter("surgicalAppointmentAttributes")
@@ -205,19 +207,40 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 	
 	@PropertyGetter("patientObservations")
 	public static List<Obs> getPatientObservations(SurgicalAppointment surgicalAppointment) {
-		String obsConceptMappings = Context.getAdministrationService().getGlobalProperty("obs.conceptMappingsForOT");
 		List<Obs> obsList = new ArrayList<Obs>();
+		String obsConceptMappings = Context.getAdministrationService().getGlobalProperty("obs.conceptMappingsForOT");
 		if (StringUtils.isNotBlank(obsConceptMappings)) {
 			String[] conceptMappingList = obsConceptMappings.split(",");
 			for (String conceptMapping : conceptMappingList) {
-				String[] conceptSourceAndCode = conceptMapping.split(":");
-				Concept concept = Context.getConceptService().getConceptByMapping(conceptSourceAndCode[1],
-				    conceptSourceAndCode[0], false);
-				obsList.addAll(Context.getObsService()
-				        .getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(), concept));
+				String trimmedMapping = conceptMapping.trim();
+				String[] conceptSourceAndCode = trimmedMapping.split(":");
+				Concept concept = null;
+				
+				String source = conceptSourceAndCode[0].trim();
+				String code = (conceptSourceAndCode.length > 1 && StringUtils.isNotBlank(conceptSourceAndCode[1]))
+				        ? conceptSourceAndCode[1].trim()
+				        : null;
+				if (StringUtils.isNotBlank(code)) {
+					concept = Context.getConceptService().getConceptByMapping(code, source, false);
+				} else if (StringUtils.isNotBlank(source)) {
+					concept = Context.getConceptService().getConceptByName(source);
+				}
+				
+				if (concept != null) {
+					List<Obs> conceptObs = Context.getObsService()
+					        .getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(), concept);
+					if (conceptObs != null) {
+						obsList.addAll(conceptObs);
+					}
+				}
 			}
 		}
-		Collections.sort(obsList, (Obs o1, Obs o2) -> o2.getObsId().compareTo(o1.getObsId()));
+		Collections.sort(obsList, (o1, o2) -> {
+			if (o1.getObsId() == null || o2.getObsId() == null) {
+				return 0;
+			}
+			return o2.getObsId().compareTo(o1.getObsId());
+		});
 		return obsList;
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResourceTest.java
@@ -46,13 +46,13 @@ public class SurgicalAppointmentResourceTest {
 	
 	@Mock
 	BedManagementService bedManagementService;
-
+	
 	@Mock
 	private AdministrationService administrationService;
-
+	
 	@Mock
 	private ConceptService conceptService;
-
+	
 	@Mock
 	private ObsService obsService;
 	
@@ -135,40 +135,68 @@ public class SurgicalAppointmentResourceTest {
 		assertEquals("Ward", bedLocation);
 		verify(bedManagementService, times(1)).getBedAssignmentDetailsByPatient(patient);
 	}
-
+	
 	@Test
 	public void shouldGetObservationsForPatient() {
 		SurgicalAppointment surgicalAppointment = new SurgicalAppointment();
-		Person person = new Person();
-		person.setPersonId(1);
 		Patient patient = new Patient();
 		patient.setUuid("uuid");
 		patient.setPersonId(1);
 		surgicalAppointment.setPatient(patient);
-
+		
 		Concept concept = new Concept();
 		concept.setUuid("conceptuuid");
 		concept.setConceptId(1);
-
+		
 		Obs obs = new Obs();
 		obs.setObsId(1);
 		obs.setConcept(concept);
-		obs.setPerson(person);
+		obs.setPerson(patient);
 		obs.setObsDatetime(new Date());
 		List<Obs> expectedObsList = new ArrayList<Obs>();
 		expectedObsList.add(obs);
-
+		
 		when(administrationService.getGlobalProperty("obs.conceptMappingsForOT")).thenReturn("emrsource:observation");
 		when(conceptService.getConceptByMapping("observation", "emrsource", false)).thenReturn(concept);
-		when(obsService.getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(), concept))
-		        .thenReturn(expectedObsList);
-
+		when(obsService.getObservationsByPersonAndConcept(patient, concept)).thenReturn(expectedObsList);
+		
 		List<Obs> actualObsList = SurgicalAppointmentResource.getPatientObservations(surgicalAppointment);
-
+		
 		assertEquals(expectedObsList, actualObsList);
 		verify(administrationService, times(1)).getGlobalProperty("obs.conceptMappingsForOT");
 		verify(conceptService, times(1)).getConceptByMapping("observation", "emrsource", false);
-		verify(obsService, times(1)).getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(),
-		    concept);
+		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, concept);
+	}
+	
+	@Test
+	public void shouldGetObservationsForPatientWithConceptName() {
+		SurgicalAppointment surgicalAppointment = new SurgicalAppointment();
+		Patient patient = new Patient();
+		patient.setUuid("uuid");
+		patient.setPersonId(1);
+		surgicalAppointment.setPatient(patient);
+		
+		Concept concept = new Concept();
+		concept.setUuid("conceptuuid");
+		concept.setConceptId(2);
+		
+		Obs obs = new Obs();
+		obs.setObsId(2);
+		obs.setConcept(concept);
+		obs.setPerson(patient);
+		obs.setObsDatetime(new Date());
+		List<Obs> expectedObsList = new ArrayList<Obs>();
+		expectedObsList.add(obs);
+		
+		when(administrationService.getGlobalProperty("obs.conceptMappingsForOT")).thenReturn("BloodPressure");
+		when(conceptService.getConceptByName("BloodPressure")).thenReturn(concept);
+		when(obsService.getObservationsByPersonAndConcept(patient, concept)).thenReturn(expectedObsList);
+		
+		List<Obs> actualObsList = SurgicalAppointmentResource.getPatientObservations(surgicalAppointment);
+		
+		assertEquals(expectedObsList, actualObsList);
+		verify(administrationService, times(1)).getGlobalProperty("obs.conceptMappingsForOT");
+		verify(conceptService, times(1)).getConceptByName("BloodPressure");
+		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, concept);
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResourceTest.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -198,5 +199,75 @@ public class SurgicalAppointmentResourceTest {
 		verify(administrationService, times(1)).getGlobalProperty("obs.conceptMappingsForOT");
 		verify(conceptService, times(1)).getConceptByName("BloodPressure");
 		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, concept);
+	}
+	
+	@Test
+	public void shouldGetObservationsForPatientWithMixedConceptMappingsAndReturnInDescendingObsIdOrder() {
+		SurgicalAppointment surgicalAppointment = new SurgicalAppointment();
+		Patient patient = new Patient();
+		patient.setUuid("uuid");
+		patient.setPersonId(1);
+		surgicalAppointment.setPatient(patient);
+		
+		Concept mappedConcept = new Concept();
+		mappedConcept.setUuid("mappedConceptUuid");
+		mappedConcept.setConceptId(1);
+		
+		Concept namedConcept = new Concept();
+		namedConcept.setUuid("namedConceptUuid");
+		namedConcept.setConceptId(2);
+		
+		Concept nullIdConcept = new Concept();
+		nullIdConcept.setUuid("nullIdConceptUuid");
+		nullIdConcept.setConceptId(3);
+		
+		Obs obsFromMapping = new Obs();
+		obsFromMapping.setObsId(5);
+		obsFromMapping.setConcept(mappedConcept);
+		obsFromMapping.setPerson(patient);
+		obsFromMapping.setObsDatetime(new Date());
+		List<Obs> mappedConceptObs = new ArrayList<Obs>();
+		mappedConceptObs.add(obsFromMapping);
+		
+		Obs obsFromName = new Obs();
+		obsFromName.setObsId(10);
+		obsFromName.setConcept(namedConcept);
+		obsFromName.setPerson(patient);
+		obsFromName.setObsDatetime(new Date());
+		List<Obs> namedConceptObs = new ArrayList<Obs>();
+		namedConceptObs.add(obsFromName);
+		
+		Obs obsWithNullId = new Obs();
+		obsWithNullId.setObsId(null);
+		obsWithNullId.setConcept(nullIdConcept);
+		obsWithNullId.setPerson(patient);
+		obsWithNullId.setObsDatetime(new Date());
+		List<Obs> nullIdConceptObs = new ArrayList<Obs>();
+		nullIdConceptObs.add(obsWithNullId);
+		
+		when(administrationService.getGlobalProperty("obs.conceptMappingsForOT"))
+		        .thenReturn("emrsource:observation,BloodPressure,Pulse");
+		when(conceptService.getConceptByMapping("observation", "emrsource", false)).thenReturn(mappedConcept);
+		when(conceptService.getConceptByName("BloodPressure")).thenReturn(namedConcept);
+		when(conceptService.getConceptByName("Pulse")).thenReturn(nullIdConcept);
+		
+		when(obsService.getObservationsByPersonAndConcept(patient, mappedConcept)).thenReturn(mappedConceptObs);
+		when(obsService.getObservationsByPersonAndConcept(patient, namedConcept)).thenReturn(namedConceptObs);
+		when(obsService.getObservationsByPersonAndConcept(patient, nullIdConcept)).thenReturn(nullIdConceptObs);
+		
+		List<Obs> actualObsList = SurgicalAppointmentResource.getPatientObservations(surgicalAppointment);
+		
+		assertEquals(3, actualObsList.size());
+		assertEquals(Integer.valueOf(10), actualObsList.get(0).getObsId());
+		assertEquals(Integer.valueOf(5), actualObsList.get(1).getObsId());
+		assertNull(actualObsList.get(2).getObsId());
+		
+		verify(administrationService, times(1)).getGlobalProperty("obs.conceptMappingsForOT");
+		verify(conceptService, times(1)).getConceptByMapping("observation", "emrsource", false);
+		verify(conceptService, times(1)).getConceptByName("BloodPressure");
+		verify(conceptService, times(1)).getConceptByName("Pulse");
+		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, mappedConcept);
+		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, namedConcept);
+		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, nullIdConcept);
 	}
 }


### PR DESCRIPTION
JIRA: https://openmrs.atlassian.net/browse/OTM-6

**Current Behaviour**:                                                                                                                                                                               
The global property obs.conceptMappingsForOT only accepts entries in the format source:code. The method splits each entry on : and calls ConceptService.getConceptByMapping(code, source). If an entry does not contain a colon (i.e., it is just a concept name), the lookup fails silently and no observations are returned for that concept. 

**Proposed Change**:
Introduce a dual-lookup strategy in SurgicalAppointmentResource.getPatientObservations():   
- Primary (existing): If the entry contains a colon and a non-blank code, use ConceptService.getConceptByMapping(code, source) as before.     
- Fallback (new): If no code is present (entry has no colon or code is blank), fall back to ConceptService.getConceptByName(name).  
This allows obs.conceptMappingsForOT to accept mixed entries. 

**Example**:
The global property obs.conceptMappingsForOT now accepts a comma-separated mix of mapped and unmapped concept entries:   
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-d030907c-7fff-ccb1-9c84-a8cea7cd2ae7"><div dir="ltr" style="margin-left:0pt;" align="left">
Format of Entry | Sample Value | Resolution Method
-- | -- | --
source:code (previously supported) | emrsource:observation | getConceptByMapping(code, source)
conceptName (recently introduced) | BloodPressure | getConceptByName(name)

</div></b>


Please review: @dkayiwa @ibacher 