### PR TITLE
Fix CI build by upgrading deprecated GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,13 +21,14 @@ jobs:
       JAVA_VERSION: ${{ matrix.java-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## Problem

The `Build with Maven` workflow fails on every push and pull request, and it isn't a code problem. GitHub has started automatically failing any workflow that uses `actions/cache@v2` (a breaking change in the Actions runner), so the job dies at the **Set up job → Getting action download info** step, ~3 seconds in, before the repo is even checked out or compiled:

```
##[error]This request has been automatically failed because it uses a deprecated
version of `actions/cache: v2`. Please update your workflow to use v3/v4 ...
```

Because this lives in `.github/workflows/maven.yml` on `master`, it affects `master` itself and every open PR (e.g. #23), none of which can get a green check until the workflow is updated.

## Change

Bump the deprecated actions to their current major versions:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v2` | `v4` |
| `actions/setup-java` | `v1` | `v4` |
| `actions/cache` | `v2` | `v4` |

`actions/setup-java@v4` requires an explicit `distribution`, so I set `temurin`, which provides JDK 8 (the matrix version). No build logic changes: the same `mvn clean install` / `mvn test` steps run, and the Maven cache path and key strategy are unchanged.

## Notes

- Kept the existing standalone `actions/cache` step rather than switching to `setup-java`'s built-in `cache: maven`, to keep this change minimal and the cache behaviour identical. Consolidating onto the built-in cache would be a reasonable follow-up.
- Once this merges, re-running CI on open PRs (such as #23) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
