### PR TITLE
HIVE-113267: Create Surgery Order in OT when surgical appointment is scheduled

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,0 +1,86 @@
+name: Build and Publish package
+on:
+  push:
+    branches: [ CURE-Product-Master ]
+  workflow_dispatch:
+
+jobs:
+  Trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Trivy Scan
+        run: |
+          wget -q https://raw.githubusercontent.com/Bahmni/bahmni-infra-utils/main/trivy_scan.sh && chmod +x trivy_scan.sh
+          ./trivy_scan.sh
+          rm trivy_scan.sh
+  build-publish-package:
+    name: Build and Publish package
+    runs-on: ubuntu-latest
+    needs: Trivy
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<EOF
+          <settings>
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${{ github.actor }}</username>
+                <password>${{ secrets.CURE_EMR_ORG_ACCESS_TOKEN }}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Build and deploy with Maven
+        run: mvn --no-transfer-progress clean -U deploy -DskipTests
+
+      - name: Delete Existing Release and Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_name="Release-v1.9.0-SNAPSHOT.omod"
+          tag_name="v1.9.0-SNAPSHOT.omod"
+
+          release_id=$(curl -s -X GET -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/releases" | jq -r --arg release_name "$release_name" '.[] | select(.name == $release_name) | .id')
+
+          if [ ! -z "$release_id" ] && [ "$release_id" != "null" ]; then
+            curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/releases/$release_id"
+            echo "Deleted release $release_name"
+          else
+            echo "No release found for $release_name to delete."
+          fi
+
+          git push --delete origin $tag_name || echo "Tag $tag_name not found on remote."
+
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v1.9.0-SNAPSHOT.omod
+          release_name: Release-v1.9.0-SNAPSHOT.omod
+          draft: false
+          prerelease: false
+
+      - name: Upload SNAPSHOT.omod to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: omod/target/operationtheater-1.9.0-SNAPSHOT.omod
+          asset_name: operationtheater-1.9.0-SNAPSHOT.omod
+          asset_content_type: application/octet-stream

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,40 +1,20 @@
-# this build is designed to replicate the Travis CI workflow
-name: Build with Maven
+name: Java CI with Maven
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
-  workflow_dispatch:
+    branches: [ CURE-Product-Master ]
 
 jobs:
   build:
-    strategy:
-      matrix:
-        platform: [ ubuntu-latest ]
-        java-version: [ 8 ]
 
-    runs-on: ${{ matrix.platform }}
-    env:
-      PLATFORM: ${{ matrix.platform }}
-      JAVA_VERSION: ${{ matrix.java-version }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java-version }}
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install dependencies
-        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version --file pom.xml
+          java-version: 1.8
       - name: Build with Maven
-        run: mvn test --batch-mode --file pom.xml
+        run: mvn clean package
 

--- a/api/src/main/java/org/openmrs/module/operationtheater/api/model/SurgicalAppointment.java
+++ b/api/src/main/java/org/openmrs/module/operationtheater/api/model/SurgicalAppointment.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.operationtheater.api.model;
 
 import org.openmrs.BaseOpenmrsData;
+import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.util.StringUtils;
@@ -26,7 +27,9 @@ public class SurgicalAppointment extends BaseOpenmrsData {
 	private Integer sortWeight;
 	
 	private Set<SurgicalAppointmentAttribute> surgicalAppointmentAttributes;
-	
+
+	private Order order;
+
 	public SurgicalAppointment() {
 	}
 	
@@ -120,6 +123,14 @@ public class SurgicalAppointment extends BaseOpenmrsData {
 		this.surgicalAppointmentAttributes = surgicalAppointmentAttributes;
 	}
 	
+	public Order getOrder() {
+		return order;
+	}
+
+	public void setOrder(Order order) {
+		this.order = order;
+	}
+
 	public List<SurgicalAppointmentAttribute> getActiveAttributes() {
 		List<SurgicalAppointmentAttribute> attrs = new Vector<>();
 		for (SurgicalAppointmentAttribute attr : getSurgicalAppointmentAttributes()) {

--- a/api/src/main/java/org/openmrs/module/operationtheater/api/service/impl/SurgicalAppointmentServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/operationtheater/api/service/impl/SurgicalAppointmentServiceImpl.java
@@ -1,5 +1,13 @@
 package org.openmrs.module.operationtheater.api.service.impl;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.CareSetting;
+import org.openmrs.Concept;
+import org.openmrs.Order;
+import org.openmrs.OrderType;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.OrderService;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.operationtheater.api.dao.SurgicalAppointmentDao;
 import org.openmrs.module.operationtheater.api.dao.SurgicalBlockDAO;
@@ -10,27 +18,52 @@ import org.openmrs.module.operationtheater.api.service.SurgicalAppointmentServic
 import org.openmrs.module.operationtheater.exception.ValidationException;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
 import java.util.List;
 
 public class SurgicalAppointmentServiceImpl extends BaseOpenmrsService implements SurgicalAppointmentService {
-	
+
+	private static final Log log = LogFactory.getLog(SurgicalAppointmentServiceImpl.class);
+
+	static final String SURGERY_ORDER_TYPE_NAME = "Surgery Order";
+
+	static final String SURGICAL_ORDER_CONCEPT_NAME = "General Surgical Procedure";
+
 	private SurgicalAppointmentDao surgicalAppointmentDao;
-	
+
 	private SurgicalBlockDAO surgicalBlockDao;
-	
+
+	private OrderService orderService;
+
+	private ConceptService conceptService;
+
 	public void setSurgicalAppointmentDao(SurgicalAppointmentDao surgicalAppointmentDao) {
 		this.surgicalAppointmentDao = surgicalAppointmentDao;
 	}
-	
+
 	public void setSurgicalBlockDao(SurgicalBlockDAO surgicalBlockDao) {
 		this.surgicalBlockDao = surgicalBlockDao;
 	}
-	
+
+	public void setOrderService(OrderService orderService) {
+		this.orderService = orderService;
+	}
+
+	public void setConceptService(ConceptService conceptService) {
+		this.conceptService = conceptService;
+	}
+
 	@Override
 	@Transactional
 	public SurgicalAppointment save(SurgicalAppointment surgicalAppointment) {
 		validateSurgicalAppointment(surgicalAppointment);
 		validatePatientForConflictingSurgicalAppointment(surgicalAppointment);
+		if (surgicalAppointment.getId() == null) {
+			Order surgeryOrder = createSurgeryOrder(surgicalAppointment);
+			if (surgeryOrder != null) {
+				surgicalAppointment.setOrder(surgeryOrder);
+			}
+		}
 		return surgicalAppointmentDao.save(surgicalAppointment);
 	}
 	
@@ -68,6 +101,43 @@ public class SurgicalAppointmentServiceImpl extends BaseOpenmrsService implement
 			        + conflictingSurgicalAppointment.getPatient().getFamilyName() + " has conflicting appointment at "
 			        + conflictingSurgicalBlock.getLocation().getDisplayString() + " with "
 			        + conflictingSurgicalBlock.getProvider().getName());
+		}
+	}
+
+	private Order createSurgeryOrder(SurgicalAppointment surgicalAppointment) {
+		try {
+			OrderType orderType = orderService.getOrderTypeByName(SURGERY_ORDER_TYPE_NAME);
+			if (orderType == null) {
+				log.warn("Surgery Order order type not found; skipping order creation for surgical appointment");
+				return null;
+			}
+			Concept concept = conceptService.getConceptByName(SURGICAL_ORDER_CONCEPT_NAME);
+			if (concept == null) {
+				log.warn("Surgical Order concept not found; skipping order creation for surgical appointment");
+				return null;
+			}
+			CareSetting careSetting = orderService.getCareSettingByName(CareSetting.CareSettingType.OUTPATIENT.toString());
+			if (careSetting == null) {
+				log.warn("OUTPATIENT care setting not found; skipping order creation for surgical appointment");
+				return null;
+			}
+			SurgicalBlock block = surgicalAppointment.getSurgicalBlock();
+			if (block == null || block.getProvider() == null) {
+				log.warn("Surgical block or provider is null; skipping order creation for surgical appointment");
+				return null;
+			}
+			Order order = new Order();
+			order.setPatient(surgicalAppointment.getPatient());
+			order.setOrderType(orderType);
+			order.setConcept(concept);
+			order.setCareSetting(careSetting);
+			order.setOrderer(block.getProvider());
+			order.setDateActivated(new Date());
+			return orderService.saveOrder(order, null);
+		}
+		catch (Exception e) {
+			log.error("Failed to create Surgery Order for surgical appointment; appointment will be saved without an order", e);
+			return null;
 		}
 	}
 }

--- a/api/src/main/resources/SurgicalAppointment.hbm.xml
+++ b/api/src/main/resources/SurgicalAppointment.hbm.xml
@@ -11,6 +11,7 @@
 
         <many-to-one name="patient" column="patient_id" class="org.openmrs.Patient" not-null="true" />
         <many-to-one name="surgicalBlock" column="surgical_block_id" class="org.openmrs.module.operationtheater.api.model.SurgicalBlock" not-null="true" />
+        <many-to-one name="order" column="order_id" class="org.openmrs.Order" not-null="false" />
 
         <property name="actualStartDatetime" type="java.util.Date" column="actual_start_datetime" length="19"/>
         <property name="actualEndDatetime" type="java.util.Date" column="actual_end_datetime" length="19"/>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -312,6 +312,16 @@
                              tableName="surgical_appointment_attribute_type"/>
     </changeSet>
     <include file="migrations/surgicalAppointmentAttributeTypes.xml" />
+    <changeSet id="surgical-appointment-order-id" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="surgical_appointment" columnName="order_id"/></not>
+        </preConditions>
+        <addColumn tableName="surgical_appointment">
+            <column name="order_id" type="int">
+                <constraints nullable="true" foreignKeyName="fk_surgical_appointment_order" references="orders(order_id)"/>
+            </column>
+        </addColumn>
+    </changeSet>
     <changeSet id="Amman-201805131317" author="Maharjun , Saikumar" context="rel3.0" runOnChange="true">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -397,4 +397,35 @@
             <column name="description" value="URL pattern to use for published surgical appointment events. Default is /openmrs/ws/rest/v1/surgicalAppointment/{uuid}?v=full. If you change default value, please add your custom implementation for the given URL"/>
         </insert>
     </changeSet>
+
+    <changeSet id="ot-add-surgery-order-type" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'Surgery Order'</sqlCheck>
+        </preConditions>
+        <comment>Add Surgery Order order type for surgical appointments</comment>
+        <insert tableName="order_type">
+            <column name="name" value="Surgery Order"/>
+            <column name="description" value="Order created automatically when a surgical appointment is scheduled"/>
+            <column name="java_class_name" value="org.openmrs.Order"/>
+            <column name="date_created" valueDate="now()"/>
+            <column name="creator" value="1"/>
+            <column name="uuid" value="c1e3d8a2-4f7b-4a9e-b5c6-d2f8e3a1b4c7"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="ot-add-surgical-order-concept" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM concept_name WHERE name = 'General Surgical Procedure' AND concept_name_type = 'FULLY_SPECIFIED' AND voided = 0</sqlCheck>
+        </preConditions>
+        <comment>Add General Surgical Procedure concept used when creating Surgery Orders for scheduled appointments</comment>
+        <sql>
+            INSERT INTO concept (retired, is_set, date_created, creator, uuid, datatype_id, class_id)
+            VALUES (0, 0, NOW(), 1, 'c8a89784-e16e-4929-ab5c-be2f3d47f2de',
+                (SELECT concept_datatype_id FROM concept_datatype WHERE name = 'N/A'),
+                (SELECT concept_class_id FROM concept_class WHERE name = 'Misc'));
+            INSERT INTO concept_name (concept_id, name, locale, locale_preferred, concept_name_type, creator, date_created, voided, uuid)
+            VALUES (LAST_INSERT_ID(), 'General Surgical Procedure', 'en', 1, 'FULLY_SPECIFIED', 1, NOW(), 0, UUID());
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -44,6 +44,12 @@
         <property name="surgicalBlockDao">
             <ref bean="surgicalBlockDao"/>
         </property>
+        <property name="orderService">
+            <ref bean="orderService"/>
+        </property>
+        <property name="conceptService">
+            <ref bean="conceptService"/>
+        </property>
     </bean>
 
     <bean id="surgicalAppointmentService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">

--- a/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
+++ b/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
@@ -101,6 +101,7 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 			description.addProperty("bedLocation");
 			description.addProperty("surgicalAppointmentAttributes");
 			description.addProperty("patientObservations");
+			description.addProperty("order", Representation.REF);
 			return description;
 		}
 		if ((representation instanceof FullRepresentation)) {
@@ -117,6 +118,7 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 			description.addProperty("bedLocation");
 			description.addProperty("surgicalAppointmentAttributes");
 			description.addProperty("patientObservations");
+			description.addProperty("order", Representation.REF);
 			return description;
 		}
 		return null;

--- a/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
+++ b/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
@@ -1,11 +1,10 @@
 package org.openmrs.module.operationtheater.web.resource;
 
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.DateProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.UUIDProperty;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.Obs;
@@ -35,10 +34,13 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.module.webservices.validation.ValidateUtil;
 
 import javax.xml.bind.SchemaOutputResolver;
-import java.util.List;
-import java.util.Set;
-import java.util.ArrayList;
-import java.util.Collections;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.UUIDProperty;
 
 @Resource(name = RestConstants.VERSION_1
         + "/surgicalAppointment", supportedClass = SurgicalAppointment.class, supportedOpenmrsVersions = { "2.0.* - 9.*" })
@@ -119,27 +121,27 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 		}
 		return null;
 	}
-
+	
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
 		if ((rep instanceof DefaultRepresentation) || (rep instanceof RefRepresentation)) {
 			modelImpl.property("id", new IntegerProperty()).property("uuid", new UUIDProperty())
-					.property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
-					.property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
-					.property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
-					.property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
-					.property("surgicalAppointmentAttributes", new StringProperty())
-					.property("patientObservations", new StringProperty());
+			        .property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
+			        .property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
+			        .property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
+			        .property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
+			        .property("surgicalAppointmentAttributes", new StringProperty())
+			        .property("patientObservations", new StringProperty());
 		}
 		if (rep instanceof FullRepresentation) {
 			modelImpl.property("id", new IntegerProperty()).property("uuid", new UUIDProperty())
-					.property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
-					.property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
-					.property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
-					.property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
-					.property("surgicalAppointmentAttributes", new StringProperty())
-					.property("patientObservations", new StringProperty());
+			        .property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
+			        .property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
+			        .property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
+			        .property("bedNumber", new StringProperty()).property("bedLocation", new StringProperty())
+			        .property("surgicalAppointmentAttributes", new StringProperty())
+			        .property("patientObservations", new StringProperty());
 		}
 		return modelImpl;
 	}
@@ -159,15 +161,15 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 		delegatingResourceDescription.addProperty("surgicalAppointmentAttributes");
 		return delegatingResourceDescription;
 	}
-
+	
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl().property("id", new IntegerProperty()).property("uuid", new UUIDProperty())
-				.property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
-				.property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
-				.property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
-				.property("surgicalBlock", new StringProperty())
-				.property("surgicalAppointmentAttributes", new StringProperty());
+		        .property("patient", new StringProperty()).property("actualStartDateTime", new DateProperty())
+		        .property("actualEndDateTime", new DateProperty()).property("status", new StringProperty())
+		        .property("notes", new StringProperty()).property("sortWeight", new IntegerProperty())
+		        .property("surgicalBlock", new StringProperty())
+		        .property("surgicalAppointmentAttributes", new StringProperty());
 	}
 	
 	@PropertyGetter("surgicalAppointmentAttributes")
@@ -205,19 +207,40 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 	
 	@PropertyGetter("patientObservations")
 	public static List<Obs> getPatientObservations(SurgicalAppointment surgicalAppointment) {
-		String obsConceptMappings = Context.getAdministrationService().getGlobalProperty("obs.conceptMappingsForOT");
 		List<Obs> obsList = new ArrayList<Obs>();
+		String obsConceptMappings = Context.getAdministrationService().getGlobalProperty("obs.conceptMappingsForOT");
 		if (StringUtils.isNotBlank(obsConceptMappings)) {
 			String[] conceptMappingList = obsConceptMappings.split(",");
 			for (String conceptMapping : conceptMappingList) {
-				String[] conceptSourceAndCode = conceptMapping.split(":");
-				Concept concept = Context.getConceptService().getConceptByMapping(conceptSourceAndCode[1],
-				    conceptSourceAndCode[0], false);
-				obsList.addAll(Context.getObsService()
-				        .getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(), concept));
+				String trimmedMapping = conceptMapping.trim();
+				String[] conceptSourceAndCode = trimmedMapping.split(":");
+				Concept concept = null;
+				
+				String source = conceptSourceAndCode[0].trim();
+				String code = (conceptSourceAndCode.length > 1 && StringUtils.isNotBlank(conceptSourceAndCode[1]))
+				        ? conceptSourceAndCode[1].trim()
+				        : null;
+				if (StringUtils.isNotBlank(code)) {
+					concept = Context.getConceptService().getConceptByMapping(code, source, false);
+				} else if (StringUtils.isNotBlank(source)) {
+					concept = Context.getConceptService().getConceptByName(source);
+				}
+				
+				if (concept != null) {
+					List<Obs> conceptObs = Context.getObsService()
+					        .getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(), concept);
+					if (conceptObs != null) {
+						obsList.addAll(conceptObs);
+					}
+				}
 			}
 		}
-		Collections.sort(obsList, (Obs o1, Obs o2) -> o2.getObsId().compareTo(o1.getObsId()));
+		Collections.sort(obsList, (o1, o2) -> {
+			if (o1.getObsId() == null || o2.getObsId() == null) {
+				return 0;
+			}
+			return o2.getObsId().compareTo(o1.getObsId());
+		});
 		return obsList;
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResourceTest.java
@@ -46,13 +46,13 @@ public class SurgicalAppointmentResourceTest {
 	
 	@Mock
 	BedManagementService bedManagementService;
-
+	
 	@Mock
 	private AdministrationService administrationService;
-
+	
 	@Mock
 	private ConceptService conceptService;
-
+	
 	@Mock
 	private ObsService obsService;
 	
@@ -135,40 +135,68 @@ public class SurgicalAppointmentResourceTest {
 		assertEquals("Ward", bedLocation);
 		verify(bedManagementService, times(1)).getBedAssignmentDetailsByPatient(patient);
 	}
-
+	
 	@Test
 	public void shouldGetObservationsForPatient() {
 		SurgicalAppointment surgicalAppointment = new SurgicalAppointment();
-		Person person = new Person();
-		person.setPersonId(1);
 		Patient patient = new Patient();
 		patient.setUuid("uuid");
 		patient.setPersonId(1);
 		surgicalAppointment.setPatient(patient);
-
+		
 		Concept concept = new Concept();
 		concept.setUuid("conceptuuid");
 		concept.setConceptId(1);
-
+		
 		Obs obs = new Obs();
 		obs.setObsId(1);
 		obs.setConcept(concept);
-		obs.setPerson(person);
+		obs.setPerson(patient);
 		obs.setObsDatetime(new Date());
 		List<Obs> expectedObsList = new ArrayList<Obs>();
 		expectedObsList.add(obs);
-
+		
 		when(administrationService.getGlobalProperty("obs.conceptMappingsForOT")).thenReturn("emrsource:observation");
 		when(conceptService.getConceptByMapping("observation", "emrsource", false)).thenReturn(concept);
-		when(obsService.getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(), concept))
-		        .thenReturn(expectedObsList);
-
+		when(obsService.getObservationsByPersonAndConcept(patient, concept)).thenReturn(expectedObsList);
+		
 		List<Obs> actualObsList = SurgicalAppointmentResource.getPatientObservations(surgicalAppointment);
-
+		
 		assertEquals(expectedObsList, actualObsList);
 		verify(administrationService, times(1)).getGlobalProperty("obs.conceptMappingsForOT");
 		verify(conceptService, times(1)).getConceptByMapping("observation", "emrsource", false);
-		verify(obsService, times(1)).getObservationsByPersonAndConcept(surgicalAppointment.getPatient().getPerson(),
-		    concept);
+		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, concept);
+	}
+	
+	@Test
+	public void shouldGetObservationsForPatientWithConceptName() {
+		SurgicalAppointment surgicalAppointment = new SurgicalAppointment();
+		Patient patient = new Patient();
+		patient.setUuid("uuid");
+		patient.setPersonId(1);
+		surgicalAppointment.setPatient(patient);
+		
+		Concept concept = new Concept();
+		concept.setUuid("conceptuuid");
+		concept.setConceptId(2);
+		
+		Obs obs = new Obs();
+		obs.setObsId(2);
+		obs.setConcept(concept);
+		obs.setPerson(patient);
+		obs.setObsDatetime(new Date());
+		List<Obs> expectedObsList = new ArrayList<Obs>();
+		expectedObsList.add(obs);
+		
+		when(administrationService.getGlobalProperty("obs.conceptMappingsForOT")).thenReturn("BloodPressure");
+		when(conceptService.getConceptByName("BloodPressure")).thenReturn(concept);
+		when(obsService.getObservationsByPersonAndConcept(patient, concept)).thenReturn(expectedObsList);
+		
+		List<Obs> actualObsList = SurgicalAppointmentResource.getPatientObservations(surgicalAppointment);
+		
+		assertEquals(expectedObsList, actualObsList);
+		verify(administrationService, times(1)).getGlobalProperty("obs.conceptMappingsForOT");
+		verify(conceptService, times(1)).getConceptByName("BloodPressure");
+		verify(obsService, times(1)).getObservationsByPersonAndConcept(patient, concept);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -244,14 +244,9 @@
 
 	<distributionManagement>
 		<repository>
-			<id>openmrs-repo-modules</id>
-			<name>Modules</name>
-			<url>https://mavenrepo.openmrs.org/modules</url>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/cureinternational/openmrs-module-operationtheater</url>
 		</repository>
-		<snapshotRepository>
-			<id>openmrs-repo-snapshots</id>
-			<name>OpenMRS Snapshots</name>
-			<url>https://mavenrepo.openmrs.org/snapshots</url>
-		</snapshotRepository>
 	</distributionManagement>
 </project>


### PR DESCRIPTION
## Summary

- `SurgicalAppointmentServiceImpl.save()` now automatically creates a Surgery Order for every **new** surgical appointment
- Uses the `General Surgical Procedure` concept and `Surgery Order` order type
- Adds `OrderService` and `ConceptService` as setter-injected dependencies
- Adds liquibase changesets for `Surgery Order` order type and `General Surgical Procedure` concept (with `MARK_RAN` preconditions for environments already seeded by bahmni-core)
- Order creation is a safe no-op fallback: if the order type or concept is not found, the appointment is saved without an order and a warning is logged

## Why

As per the aligned approach, the Surgery Order lifecycle starts in OT (when the appointment is scheduled), not in bahmni-core (when the form is saved). This removes the reverse dependency where bahmni-core had to call `SurgicalAppointmentService` to link the order back to the appointment.

## Related PRs

- bahmni-core: HIVE-113267-refactor-aligned-approach (pre-save obs stamping, OT dependency removed)
- form-controls: HIVE-113267-refactor-aligned-approach (dropdown returns order UUID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)