### PR TITLE
BAH-4917 | Add. Surgery Order creation on surgical appointment scheduling

### DIFF
--- a/api/src/main/java/org/openmrs/module/operationtheater/api/model/SurgicalAppointment.java
+++ b/api/src/main/java/org/openmrs/module/operationtheater/api/model/SurgicalAppointment.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.operationtheater.api.model;
 
 import org.openmrs.BaseOpenmrsData;
+import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.util.StringUtils;
@@ -26,7 +27,9 @@ public class SurgicalAppointment extends BaseOpenmrsData {
 	private Integer sortWeight;
 	
 	private Set<SurgicalAppointmentAttribute> surgicalAppointmentAttributes;
-	
+
+	private Order order;
+
 	public SurgicalAppointment() {
 	}
 	
@@ -120,6 +123,14 @@ public class SurgicalAppointment extends BaseOpenmrsData {
 		this.surgicalAppointmentAttributes = surgicalAppointmentAttributes;
 	}
 	
+	public Order getOrder() {
+		return order;
+	}
+
+	public void setOrder(Order order) {
+		this.order = order;
+	}
+
 	public List<SurgicalAppointmentAttribute> getActiveAttributes() {
 		List<SurgicalAppointmentAttribute> attrs = new Vector<>();
 		for (SurgicalAppointmentAttribute attr : getSurgicalAppointmentAttributes()) {

--- a/api/src/main/java/org/openmrs/module/operationtheater/api/service/impl/SurgicalBlockServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/operationtheater/api/service/impl/SurgicalBlockServiceImpl.java
@@ -1,5 +1,18 @@
 package org.openmrs.module.operationtheater.api.service.impl;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.CareSetting;
+import org.openmrs.Concept;
+import org.openmrs.Encounter;
+import org.openmrs.EncounterType;
+import org.openmrs.Order;
+import org.openmrs.OrderType;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.OrderService;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.operationtheater.api.dao.SurgicalBlockDAO;
 import org.openmrs.module.operationtheater.api.model.SurgicalAppointment;
@@ -8,21 +21,73 @@ import org.openmrs.module.operationtheater.api.service.SurgicalBlockService;
 import org.openmrs.module.operationtheater.exception.ValidationException;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 public class SurgicalBlockServiceImpl extends BaseOpenmrsService implements SurgicalBlockService {
 	
+	private static final Log log = LogFactory.getLog(SurgicalBlockServiceImpl.class);
+	
+	static final String SURGERY_ORDER_TYPE_UUID = "c1e3d8a2-4f7b-4a9e-b5c6-d2f8e3a1b4c7";
+	
+	static final String SURGICAL_ORDER_CONCEPT_UUID = "c8a89784-e16e-4929-ab5c-be2f3d47f2de";
+	
+	static final String SURGERY_SCHEDULING_ENCOUNTER_TYPE_GP = "operationtheater.surgerySchedulingEncounterTypeUuid";
+	
 	SurgicalBlockDAO surgicalBlockDAO;
+	
+	private OrderService orderService;
+	
+	private ConceptService conceptService;
+	
+	private EncounterService encounterService;
+	
+	private AdministrationService adminService;
 	
 	public void setSurgicalBlockDAO(SurgicalBlockDAO surgicalBlockDAO) {
 		this.surgicalBlockDAO = surgicalBlockDAO;
 	}
 	
+	public void setOrderService(OrderService orderService) {
+		this.orderService = orderService;
+	}
+	
+	public void setConceptService(ConceptService conceptService) {
+		this.conceptService = conceptService;
+	}
+	
+	public void setEncounterService(EncounterService encounterService) {
+		this.encounterService = encounterService;
+	}
+	
+	public void setAdminService(AdministrationService adminService) {
+		this.adminService = adminService;
+	}
+	
 	@Override
 	@Transactional
 	public SurgicalBlock save(SurgicalBlock surgicalBlock) {
+		// Snapshot new appointments BEFORE validation triggers Hibernate flush (which
+		// assigns IDs)
+		List<SurgicalAppointment> newAppointments = new ArrayList<>();
+		for (SurgicalAppointment appointment : surgicalBlock.getSurgicalAppointments()) {
+			if (!appointment.getVoided() && appointment.getId() == null) {
+				newAppointments.add(appointment);
+			}
+		}
 		validateSurgicalBlock(surgicalBlock);
+		
+		for (SurgicalAppointment appointment : newAppointments) {
+			Encounter encounter = createSurgerySchedulingEncounter(appointment, surgicalBlock);
+			if (encounter != null) {
+				Order order = createSurgeryOrder(appointment, encounter, surgicalBlock);
+				if (order != null) {
+					appointment.setOrder(order);
+				}
+			}
+		}
+		
 		return surgicalBlockDAO.save(surgicalBlock);
 	}
 	
@@ -78,5 +143,61 @@ public class SurgicalBlockServiceImpl extends BaseOpenmrsService implements Surg
 	private List<SurgicalBlock> getOverlappingSurgicalBlocksForLocation(SurgicalBlock surgicalBlock) {
 		return surgicalBlockDAO.getOverlappingSurgicalBlocksFor(surgicalBlock.getStartDatetime(),
 		    surgicalBlock.getEndDatetime(), null, surgicalBlock.getLocation(), surgicalBlock.getId());
+	}
+	
+	private Encounter createSurgerySchedulingEncounter(SurgicalAppointment appointment, SurgicalBlock block) {
+		String encounterTypeUuid = adminService.getGlobalProperty(SURGERY_SCHEDULING_ENCOUNTER_TYPE_GP, "");
+		if (StringUtils.isBlank(encounterTypeUuid)) {
+			log.warn("operationtheater.surgerySchedulingEncounterTypeUuid GP not configured; skipping order creation");
+			return null;
+		}
+		EncounterType encounterType = encounterService.getEncounterTypeByUuid(encounterTypeUuid);
+		if (encounterType == null) {
+			log.warn(
+			    "SURGERY_SCHEDULING encounter type not found for uuid: " + encounterTypeUuid + "; skipping order creation");
+			return null;
+		}
+		// Visit is intentionally not set — this encounter exists solely as an OpenMRS
+		// context anchor for the Surgery Order (which requires an encounter). It is not
+		// a clinical visit and does not appear in patient visit timelines.
+		Encounter encounter = new Encounter();
+		encounter.setPatient(appointment.getPatient());
+		encounter.setEncounterType(encounterType);
+		encounter.setEncounterDatetime(new Date());
+		if (block.getLocation() != null) {
+			encounter.setLocation(block.getLocation());
+		}
+		return encounterService.saveEncounter(encounter);
+	}
+	
+	private Order createSurgeryOrder(SurgicalAppointment appointment, Encounter encounter, SurgicalBlock block) {
+		OrderType orderType = orderService.getOrderTypeByUuid(SURGERY_ORDER_TYPE_UUID);
+		if (orderType == null) {
+			log.warn("Surgery Order order type not found; skipping order creation");
+			return null;
+		}
+		Concept concept = conceptService.getConceptByUuid(SURGICAL_ORDER_CONCEPT_UUID);
+		if (concept == null) {
+			log.warn("General Surgical Procedure concept not found; skipping order creation");
+			return null;
+		}
+		CareSetting careSetting = orderService.getCareSettingByName(CareSetting.CareSettingType.OUTPATIENT.toString());
+		if (careSetting == null) {
+			log.warn("OUTPATIENT care setting not found; skipping order creation");
+			return null;
+		}
+		if (block.getProvider() == null) {
+			log.warn("Surgical block provider is null; skipping order creation");
+			return null;
+		}
+		Order order = new Order();
+		order.setPatient(appointment.getPatient());
+		order.setEncounter(encounter);
+		order.setOrderType(orderType);
+		order.setConcept(concept);
+		order.setCareSetting(careSetting);
+		order.setOrderer(block.getProvider());
+		order.setDateActivated(new Date());
+		return orderService.saveOrder(order, null);
 	}
 }

--- a/api/src/main/resources/SurgicalAppointment.hbm.xml
+++ b/api/src/main/resources/SurgicalAppointment.hbm.xml
@@ -11,6 +11,7 @@
 
         <many-to-one name="patient" column="patient_id" class="org.openmrs.Patient" not-null="true" />
         <many-to-one name="surgicalBlock" column="surgical_block_id" class="org.openmrs.module.operationtheater.api.model.SurgicalBlock" not-null="true" />
+        <many-to-one name="order" column="order_id" class="org.openmrs.Order" not-null="false" />
 
         <property name="actualStartDatetime" type="java.util.Date" column="actual_start_datetime" length="19"/>
         <property name="actualEndDatetime" type="java.util.Date" column="actual_end_datetime" length="19"/>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -312,6 +312,16 @@
                              tableName="surgical_appointment_attribute_type"/>
     </changeSet>
     <include file="migrations/surgicalAppointmentAttributeTypes.xml" />
+    <changeSet id="surgical-appointment-order-id" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="surgical_appointment" columnName="order_id"/></not>
+        </preConditions>
+        <addColumn tableName="surgical_appointment">
+            <column name="order_id" type="int">
+                <constraints nullable="true" foreignKeyName="fk_surgical_appointment_order" references="orders(order_id)"/>
+            </column>
+        </addColumn>
+    </changeSet>
     <changeSet id="Amman-201805131317" author="Maharjun , Saikumar" context="rel3.0" runOnChange="true">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -397,4 +397,62 @@
             <column name="description" value="URL pattern to use for published surgical appointment events. Default is /openmrs/ws/rest/v1/surgicalAppointment/{uuid}?v=full. If you change default value, please add your custom implementation for the given URL"/>
         </insert>
     </changeSet>
+
+    <changeSet id="ot-add-surgery-scheduling-encounter-type" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM encounter_type WHERE name = 'SURGERY_SCHEDULING'</sqlCheck>
+        </preConditions>
+        <comment>Encounter created during surgery scheduling to associate a Surgery Order with the scheduled surgical appointment</comment>
+        <insert tableName="encounter_type">
+            <column name="name" value="SURGERY_SCHEDULING"/>
+            <column name="description" value="Encounter created during surgery scheduling to associate a Surgery Order with the scheduled surgical appointment"/>
+            <column name="creator" value="1"/>
+            <column name="date_created" valueDate="now()"/>
+            <column name="uuid" value="a2d9f6b3-1c4e-4a7f-b8d2-e5f3c1a6d9b4"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="ot-add-surgery-scheduling-encounter-type-gp" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM global_property WHERE property = 'operationtheater.surgerySchedulingEncounterTypeUuid'</sqlCheck>
+        </preConditions>
+        <comment>GP for configurable SURGERY_SCHEDULING encounter type UUID used when creating Surgery Orders</comment>
+        <insert tableName="global_property">
+            <column name="property" value="operationtheater.surgerySchedulingEncounterTypeUuid"/>
+            <column name="property_value" value="a2d9f6b3-1c4e-4a7f-b8d2-e5f3c1a6d9b4"/>
+            <column name="uuid" valueComputed="UUID()"/>
+            <column name="description" value="UUID of the encounter type used when creating a Surgery Scheduling encounter. Configurable to use a site-specific encounter type."/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="ot-add-surgery-order-type" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'Surgery Order'</sqlCheck>
+        </preConditions>
+        <comment>Add Surgery Order order type for surgical appointments</comment>
+        <insert tableName="order_type">
+            <column name="name" value="Surgery Order"/>
+            <column name="description" value="Order created automatically when a surgical appointment is scheduled"/>
+            <column name="java_class_name" value="org.openmrs.Order"/>
+            <column name="date_created" valueDate="now()"/>
+            <column name="creator" value="1"/>
+            <column name="uuid" value="c1e3d8a2-4f7b-4a9e-b5c6-d2f8e3a1b4c7"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="ot-add-surgical-order-concept" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM concept_name WHERE name = 'General Surgical Procedure' AND concept_name_type = 'FULLY_SPECIFIED' AND voided = 0</sqlCheck>
+        </preConditions>
+        <comment>Add General Surgical Procedure concept used when creating Surgery Orders for scheduled appointments</comment>
+        <sql>
+            INSERT INTO concept (retired, is_set, date_created, creator, uuid, datatype_id, class_id)
+            VALUES (0, 0, NOW(), 1, 'c8a89784-e16e-4929-ab5c-be2f3d47f2de',
+                (SELECT concept_datatype_id FROM concept_datatype WHERE name = 'N/A'),
+                (SELECT concept_class_id FROM concept_class WHERE name = 'Misc'));
+            INSERT INTO concept_name (concept_id, name, locale, locale_preferred, concept_name_type, creator, date_created, voided, uuid)
+            VALUES (LAST_INSERT_ID(), 'General Surgical Procedure', 'en', 1, 'FULLY_SPECIFIED', 1, NOW(), 0, UUID());
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -74,6 +74,18 @@
         <property name="surgicalBlockDAO">
             <ref bean="surgicalBlockDao"/>
         </property>
+        <property name="orderService">
+            <ref bean="orderService"/>
+        </property>
+        <property name="conceptService">
+            <ref bean="conceptService"/>
+        </property>
+        <property name="encounterService">
+            <ref bean="encounterService"/>
+        </property>
+        <property name="adminService">
+            <ref bean="adminService"/>
+        </property>
     </bean>
 
     <bean id="surgicalBlockService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">

--- a/api/src/test/java/org/openmrs/module/operationtheater/api/service/impl/SurgicalBlockServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/operationtheater/api/service/impl/SurgicalBlockServiceImplTest.java
@@ -8,6 +8,10 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.openmrs.*;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
 
 import org.openmrs.module.operationtheater.api.dao.SurgicalBlockDAO;
@@ -22,7 +26,9 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -32,6 +38,18 @@ public class SurgicalBlockServiceImplTest {
 	
 	@Mock
 	SurgicalBlockDAO surgicalBlockDAO;
+	
+	@Mock
+	AdministrationService adminService;
+	
+	@Mock
+	EncounterService encounterService;
+	
+	@Mock
+	OrderService orderService;
+	
+	@Mock
+	ConceptService conceptService;
 	
 	@InjectMocks
 	SurgicalBlockServiceImpl surgicalBlockService;
@@ -266,5 +284,118 @@ public class SurgicalBlockServiceImplTest {
 		
 		verify(surgicalBlockDAO, times(1)).getSurgicalBlocksFor(startDatetime, endDatetime, null, null, false, true);
 		assertEquals(surgicalBlock, surgicalBlocks.get(0));
+	}
+	
+	@Test
+	public void shouldCreateEncounterAndOrderForNewAppointment() throws ParseException {
+		SurgicalBlock block = buildValidBlock();
+		SurgicalAppointment newAppointment = buildNewAppointment(block);
+		block.setSurgicalAppointments(Collections.singleton(newAppointment));
+		setupOrderCreationMocks();
+		Encounter savedEncounter = new Encounter();
+		Order savedOrder = new Order();
+		when(encounterService.saveEncounter(any(Encounter.class))).thenReturn(savedEncounter);
+		when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(savedOrder);
+		when(surgicalBlockDAO.save(block)).thenReturn(block);
+		
+		surgicalBlockService.save(block);
+		
+		verify(encounterService, times(1)).saveEncounter(any(Encounter.class));
+		verify(orderService, times(1)).saveOrder(any(Order.class), eq(null));
+		assertEquals(savedOrder, newAppointment.getOrder());
+	}
+	
+	@Test
+	public void shouldSkipOrderCreationForExistingAppointment() throws ParseException {
+		SurgicalBlock block = buildValidBlock();
+		SurgicalAppointment existingAppointment = buildNewAppointment(block);
+		existingAppointment.setId(99); // already persisted
+		block.setSurgicalAppointments(Collections.singleton(existingAppointment));
+		when(surgicalBlockDAO.save(block)).thenReturn(block);
+		
+		surgicalBlockService.save(block);
+		
+		verify(encounterService, never()).saveEncounter(any(Encounter.class));
+		verify(orderService, never()).saveOrder(any(Order.class), any());
+		assertNull(existingAppointment.getOrder());
+	}
+	
+	@Test
+	public void shouldSkipOrderCreationForVoidedNewAppointment() throws ParseException {
+		SurgicalBlock block = buildValidBlock();
+		SurgicalAppointment voidedAppointment = buildNewAppointment(block);
+		voidedAppointment.setVoided(true);
+		block.setSurgicalAppointments(Collections.singleton(voidedAppointment));
+		when(surgicalBlockDAO.save(block)).thenReturn(block);
+		
+		surgicalBlockService.save(block);
+		
+		verify(encounterService, never()).saveEncounter(any(Encounter.class));
+		verify(orderService, never()).saveOrder(any(Order.class), any());
+	}
+	
+	@Test
+	public void shouldNotSetOrderWhenGPNotConfigured() throws ParseException {
+		SurgicalBlock block = buildValidBlock();
+		SurgicalAppointment newAppointment = buildNewAppointment(block);
+		block.setSurgicalAppointments(Collections.singleton(newAppointment));
+		when(adminService.getGlobalProperty(SurgicalBlockServiceImpl.SURGERY_SCHEDULING_ENCOUNTER_TYPE_GP, ""))
+		        .thenReturn("");
+		when(surgicalBlockDAO.save(block)).thenReturn(block);
+		
+		surgicalBlockService.save(block);
+		
+		verify(encounterService, never()).saveEncounter(any(Encounter.class));
+		assertNull(newAppointment.getOrder());
+	}
+	
+	@Test
+	public void shouldPropagateExceptionWhenOrderSaveFails() throws ParseException {
+		SurgicalBlock block = buildValidBlock();
+		SurgicalAppointment newAppointment = buildNewAppointment(block);
+		block.setSurgicalAppointments(Collections.singleton(newAppointment));
+		setupOrderCreationMocks();
+		Encounter savedEncounter = new Encounter();
+		when(encounterService.saveEncounter(any(Encounter.class))).thenReturn(savedEncounter);
+		when(orderService.saveOrder(any(Order.class), eq(null))).thenThrow(new RuntimeException("Order save failed"));
+		
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("Order save failed");
+		surgicalBlockService.save(block);
+	}
+	
+	private SurgicalBlock buildValidBlock() throws ParseException {
+		SurgicalBlock block = new SurgicalBlock();
+		block.setStartDatetime(simpleDateFormat.parse("2017-04-25 13:45:00"));
+		block.setEndDatetime(simpleDateFormat.parse("2017-04-25 14:45:00"));
+		block.setLocation(new Location(1));
+		Provider provider = new Provider(1);
+		block.setProvider(provider);
+		when(surgicalBlockDAO.getOverlappingSurgicalBlocksFor(any(), any(), any(), eq(null), any()))
+		        .thenReturn(new ArrayList<>());
+		when(surgicalBlockDAO.getOverlappingSurgicalBlocksFor(any(), any(), eq(null), any(), any()))
+		        .thenReturn(new ArrayList<>());
+		when(surgicalBlockDAO.getOverlappingSurgicalAppointmentsForPatient(any(), any(), any(), any()))
+		        .thenReturn(new ArrayList<>());
+		return block;
+	}
+	
+	private SurgicalAppointment buildNewAppointment(SurgicalBlock block) {
+		SurgicalAppointment appointment = new SurgicalAppointment();
+		appointment.setPatient(new Patient(1));
+		appointment.setSurgicalBlock(block);
+		return appointment; // getId() == null → new appointment
+	}
+	
+	private void setupOrderCreationMocks() {
+		when(adminService.getGlobalProperty(SurgicalBlockServiceImpl.SURGERY_SCHEDULING_ENCOUNTER_TYPE_GP, ""))
+		        .thenReturn("encounter-type-uuid");
+		EncounterType encounterType = new EncounterType();
+		when(encounterService.getEncounterTypeByUuid("encounter-type-uuid")).thenReturn(encounterType);
+		when(orderService.getOrderTypeByUuid(SurgicalBlockServiceImpl.SURGERY_ORDER_TYPE_UUID)).thenReturn(new OrderType());
+		when(conceptService.getConceptByUuid(SurgicalBlockServiceImpl.SURGICAL_ORDER_CONCEPT_UUID))
+		        .thenReturn(new Concept());
+		when(orderService.getCareSettingByName(CareSetting.CareSettingType.OUTPATIENT.toString()))
+		        .thenReturn(new CareSetting());
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
+++ b/omod/src/main/java/org/openmrs/module/operationtheater/web/resource/SurgicalAppointmentResource.java
@@ -101,6 +101,7 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 			description.addProperty("bedLocation");
 			description.addProperty("surgicalAppointmentAttributes");
 			description.addProperty("patientObservations");
+			description.addProperty("order", Representation.REF);
 			return description;
 		}
 		if ((representation instanceof FullRepresentation)) {
@@ -117,6 +118,7 @@ public class SurgicalAppointmentResource extends DataDelegatingCrudResource<Surg
 			description.addProperty("bedLocation");
 			description.addProperty("surgicalAppointmentAttributes");
 			description.addProperty("patientObservations");
+			description.addProperty("order", Representation.REF);
 			return description;
 		}
 		return null;


### PR DESCRIPTION
## Summary

Adds Surgery Order creation and linkage to the Operation Theater module as part of the Nurse Acknowledgement of Physician Instructions workflow. When a surgical appointment is scheduled, the OT module now automatically creates a Surgery Order and links it to the appointment — enabling care instruction observations from operative report forms to be traceable back to the surgery.

## Changes

### HIVE-113267 — Add order_id linkage to surgical_appointment
- Adds `order_id` column to `surgical_appointment` table via Liquibase migration
- Exposes `order` field in `SurgicalAppointmentResource` GET response so consumers can read the linked order UUID

### HIVE-107135 — Create Surgery Order on scheduling
- `SurgicalBlockService`: on save, creates a Surgery Order for each newly added surgical appointment using a configurable `General Surgical Procedure` concept
- Creates a `SURGERY_SCHEDULING` encounter to house the order (required by OpenMRS order creation)
- Snapshots new appointments before validation to correctly identify newly added vs pre-existing ones
- Only creates orders for new appointments — edits do not trigger duplicate order creation
- Uses UUID-based concept and order type lookups for reliability

## Related PRs (CURE fork)
- [HIVE-113267: Add order_id linkage to surgical_appointment](https://github.com/cureinternational/openmrs-module-operationtheater/pull/1)
- [HIVE-107135: Create Surgery Order in OT when surgical appointment is scheduled](https://github.com/cureinternational/openmrs-module-operationtheater/pull/3)

## Testing

Verify end-to-end order linkage after scheduling a surgery:
```sql
SELECT
    sa.uuid   AS surgical_appointment,
    o.uuid    AS order_uuid,
    ot.name   AS order_type,
    cn.name   AS concept
FROM surgical_appointment sa
    LEFT JOIN orders o      ON o.order_id = sa.order_id AND o.voided = 0
    LEFT JOIN order_type ot ON ot.order_type_id = o.order_type_id
    LEFT JOIN concept_name cn ON cn.concept_id = o.concept_id
        AND cn.concept_name_type = 'FULLY_SPECIFIED' AND cn.voided = 0
WHERE sa.voided = 0
ORDER BY sa.date_created DESC
LIMIT 10;
```